### PR TITLE
素のWordPressを起動するdocker-compose.ymlを追加しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ PC操作にはあまり馴染みのないユーザーを想定し、アップロ
 ```
 $ git clone https://github.com/team-itp/cms-proto
 $ cd server
-$ docker-compose run
+$ docker-compose up -d
 ```
 
 ## 作業の方法

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -26,8 +26,6 @@ services:
     volumes:
       - ./db-data:/var/lib/mysql
       - ./db-data:/docker-entrypoint-initdb.d
-    ports:
-      - 3306:80
 volumes:
   db-data:
     driver: local

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3"
+services:
+  wordpress:
+    image: wordpress:latest
+    ports:
+      - 80:80
+    depends_on:
+      - mysql
+    links:
+      - mysql
+    environment:
+      - WORDPRESS_DB_HOST=mysql:3306
+      - WORDPRESS_DB_NAME=testdb
+      - WORDPRESS_DB_USER=wp_user
+      - WORDPRESS_DB_PASSWORD=root
+    volumes:
+      - ./themes:/var/www/html/wp-content/themes
+  mysql:
+    image: mysql:latest
+    environment:
+      - MYSQL_ROOT_USER=root
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=testdb
+      - MYSQL_USER=wp_user
+      - MYSQL_PASSWORD=root
+    volumes:
+      - ./db-data:/var/lib/mysql
+      - ./db-data:/docker-entrypoint-initdb.d
+    ports:
+      - 3306:80
+volumes:
+  db-data:
+    driver: local


### PR DESCRIPTION
タイトルの通りです。
またREADMEのdocker-composeコマンドを修正しました。
私の環境では"docker-compose run"では起動できませんでした。